### PR TITLE
Update DebugClassLoader.php

### DIFF
--- a/src/Symfony/Component/Debug/DebugClassLoader.php
+++ b/src/Symfony/Component/Debug/DebugClassLoader.php
@@ -195,7 +195,7 @@ class DebugClassLoader
                 }
                 $parent = $refl->getParentClass();
 
-                if (!$parent || strncmp($ns, $parent, $len)) {
+                if (!$parent || strncmp($ns, $parent->name, $len)) {
                     if ($parent && isset(self::$deprecated[$parent->name]) && strncmp($ns, $parent->name, $len)) {
                         trigger_error(sprintf('The %s class extends %s that is deprecated %s', $name, $parent->name, self::$deprecated[$parent->name]), E_USER_DEPRECATED);
                     }


### PR DESCRIPTION
Using name property of ReflectionClass instance in strncmp instead of __toString() return value, the latter seemed to breaking one of hte vendor bundles we use, and it seems fine now with the former.